### PR TITLE
Fixes bug in corner case for up and down movement

### DIFF
--- a/common/main.c
+++ b/common/main.c
@@ -34,12 +34,12 @@ void main(){
 				break;
 
 			case MINE_INPUT_UP:
-				if (mf.current_cell > mf.width)
+				if (mf.current_cell > mf.width - 1)
 					mf.current_cell -= mf.width;
 				break;
 
 			case MINE_INPUT_DOWN:
-				if (mf.current_cell < num_cells - 1 - mf.width)
+				if (mf.current_cell < num_cells - mf.width)
 					mf.current_cell += mf.width;
 				break;
 


### PR DESCRIPTION
When in the first cell of the second line the up arrow wouldn't work. The same was the case for the last cell of the line before last and the down arrow.