### PR TITLE
debugging improvements

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -87,8 +87,8 @@ int random_number(int min, int max);
  * Implementation details
  * ----------------------
  *
- * Optional. You can undefine `USE_DEBUG_MODE` macro to transform debug_mode() and debug()
- * into empty macros.
+ * Optional. You can undefine `USE_DEBUG_MODE` macro to transform debug_mode(), debug()
+ * and debug_break() into empty macros.
  */
 void debug_mode(uint8_t mode);
 
@@ -99,16 +99,28 @@ void debug_mode(uint8_t mode);
  * Implementation details
  * ----------------------
  *
- * Optional. You can undefine `USE_DEBUG_MODE` macro to transform debug_mode() and debug()
- * into empty macros.
+ * Optional. You can undefine `USE_DEBUG_MODE` macro to transform debug_mode(), debug()
+ * and debug_break() into empty macros.
  */
 void debug(char* msg, uint8_t value);
+
+/**
+ * Pause emulator at debug_break function.
+ *
+ * Implementation details
+ * ----------------------
+ *
+ * Optional. You can undefine `USE_DEBUG_MODE` macro to transform debug_mode(), debug()
+ * and debug_break() into empty macros.
+ */
+void debug_break();
 
 #else
 
 /* empty macros */
 #define debug_mode(x)
 #define debug(x, y)
+#define debug_break()
 
 #endif /* USE_DEBUG_MODE */
 

--- a/common/main.c
+++ b/common/main.c
@@ -28,6 +28,7 @@ void main_gameplay_loop(minefield* mf) {
 	                   // such as running animations
 		input = input_read(KEYBOARD);
 	} while (input == MINE_INPUT_IGNORED);
+	debug("\nkey code = ", input);
 
 	uint8_t x = mf->current_cell % mf->width;
 	uint8_t y = mf->current_cell / mf->width;

--- a/common/minefield.c
+++ b/common/minefield.c
@@ -16,7 +16,7 @@ void setup_minefield(minefield* mf, uint8_t width, uint8_t height, uint8_t num_b
 	mf->width = width;
 	mf->height = height;
 	mf->current_cell = 0;
-	mf->cells = malloc(width * height * sizeof(uint8_t));
+	mf->cells = calloc(width * height, sizeof(uint8_t));
 
 	// Clear the minefield:
 	for (uint8_t x = 0; x < mf->width; x++){
@@ -55,7 +55,7 @@ void setup_minefield(minefield* mf, uint8_t width, uint8_t height, uint8_t num_b
 	}
 }
 
-void open_cell(minefield* mf, uint8_t x, uint8_t y){
+void open_cell(minefield* mf, uint8_t x, uint8_t y) {
 	if (CELL(mf, x, y) & (HASQUESTIONMARK | HASFLAG | ISOPEN)){
 		return;
 	} else {

--- a/common/minefield.h
+++ b/common/minefield.h
@@ -9,6 +9,7 @@
 #define CURRENT_CELL_X(mf)    mf->current_cell % mf->width
 #define CURRENT_CELL_Y(mf)    mf->current_cell / mf->width
 
+/* game state */
 enum {
 	TITLE_SCREEN = 1,
 	PLAYING_GAME = 2,

--- a/platforms/msx2/Makefile
+++ b/platforms/msx2/Makefile
@@ -1,9 +1,9 @@
 export PATH := $(PWD)/../../bin:$(PATH)
 
 ifeq ($(DEBUG),1)
-    CFLAGS := -DUSE_DEBUG_MODE
+    CFLAGS := $(CFLAGS) -DUSE_DEBUG_MODE
 else
-    CFLAGS :=
+    CFLAGS := $(CFLAGS)
 endif
 
 CC := sdcc
@@ -15,7 +15,7 @@ TARGET := $(BUILDDIR)/minesweeper
 CODE := 0x4000
 DATA := 0xc000
 ROM_MAX := 0x8000
-CFLAGS := $(CFLAGS) -mz80 --Werror --fsigned-char --std-sdcc99 --opt-code-speed --fomit-frame-pointer $(EXTRA_CFLAGS) -I../../common
+CFLAGS := $(CFLAGS) -mz80 --Werror --fsigned-char --std-sdcc99 --opt-code-size --fomit-frame-pointer $(EXTRA_CFLAGS) -I. -I../../common
 LDFLAGS := --no-std-crt0
 
 C_SOURCES := $(wildcard *.c)
@@ -30,16 +30,13 @@ all: $(TARGET).rom
 
 $(TARGET).rom: $(OBJECTS) $(COMMON) $(BUILDDIR)/crt0.rel
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LIBS) --code-loc $(CODE) --data-loc $(DATA) $(BUILDDIR)/crt0.rel $(OBJECTS) $(COMMON) -o $(TARGET).ihx
-	$(HEX2BIN) -e bin -p 00 -l $(ROM_MAX) $(TARGET).ihx
+	$(HEX2BIN) -e bin -p FF -l $(ROM_MAX) $(TARGET).ihx
 	@cp $(TARGET).bin $(TARGET).rom
 
 openmsx: run
 
-debug: $(TARGET).rom
-	openmsx -carta $(TARGET).rom -machine C-BIOS_MSX2 -script debugdevice.tcl
-
 run: $(TARGET).rom
-	openmsx -carta $(TARGET).rom -machine C-BIOS_MSX2
+	openmsx -carta $(TARGET).rom -machine C-BIOS_MSX2 -script debugdevice.tcl
 
 $(BUILDDIR)/%.rel: ../../common/%.c $(BUILDDIR) ../../common/common.h
 	$(CC) $(CFLAGS) $(LDFLAGS) -c $< -o $@

--- a/platforms/msx2/debug.h
+++ b/platforms/msx2/debug.h
@@ -19,13 +19,12 @@ uint8_t _stored_debug_mode = DEBUGDEVICE_INT; /* default */
 
 
 /* configure debugdevice */
-void _debug_mode(uint8_t mode) __z88dk_fastcall
+void _set_debugdevice_mode(uint8_t mode) __z88dk_fastcall
 {
     mode;
     __asm
         ld a, l
         out (#0x2e), a
-        ret
     __endasm;
 }
 
@@ -37,7 +36,6 @@ void _out2f(int8_t value) __z88dk_fastcall
     __asm
         ld a, l
         out (#0x2f), a
-        ret
     __endasm;
 }
 
@@ -52,14 +50,24 @@ void debug_mode(uint8_t mode)
 
 void debug(char* msg, uint8_t value)
 {
-    _debug_mode(DEBUGDEVICE_ASCII);
+    _set_debugdevice_mode(DEBUGDEVICE_ASCII);
 
     for (int i = 0; msg[i] != 0; ++i) {
         _out2f(msg[i]);
     }
 
-    _debug_mode(_stored_debug_mode);
+    _set_debugdevice_mode(_stored_debug_mode);
     _out2f(value);
+}
+
+
+/* pause debug device (by tcl script) */
+void debug_break()
+{
+    __asm
+        ld a, #0xff
+        out (#0x2e), a
+    __endasm;
 }
 
 #endif /* DEBUG_H*/

--- a/platforms/msx2/debugdevice.tcl
+++ b/platforms/msx2/debugdevice.tcl
@@ -1,7 +1,16 @@
-proc debug_ {{msg ""}} {
-    message $msg
-    #debug break
+proc pause {{value 0}} {
+    global use_pause
+    if {$use_pause && $value == 0xff} { debug break }
 }
 
-ext debugdevice
-#debug set_watchpoint write_io {0x2f} {} {debug_ "** $::wp_last_value received from debugdevice"}
+proc pause_on {} {
+    ext debugdevice
+    set use_pause true
+    debug set_watchpoint write_io {0x2e} {} {pause $::wp_last_value}
+}
+
+if { [info exists ::env(DEBUG)] } {
+    set use_pause $::env(DEBUG)
+    ext debugdevice
+    debug set_watchpoint write_io {0x2e} {} {pause $::wp_last_value}
+}

--- a/platforms/msx2/input.c
+++ b/platforms/msx2/input.c
@@ -1,6 +1,6 @@
-#include "msx.h"
 #include <assert.h>
 #include <stdbool.h>
+#include "msx.h"
 #include "ports.h"
 #include "common.h"
 

--- a/platforms/msx2/xorshift.z80
+++ b/platforms/msx2/xorshift.z80
@@ -1,7 +1,6 @@
 .globl _xorshift
 .globl _seed
 
-
 _set_random_seed::
     ld hl, #2
     add hl, sp


### PR DESCRIPTION
* debug_break() allows program to pause the emulator (wicked!);
* enable/disable debugging with a single environment variable in tcl script;
* calloc instead of malloc (because calloc guarantees zeroing the allocated space);
* compiling for size instead of speed (because of some SDCC 4.1.0 bug);