### PR TITLE
Add fuzzing platform (contributed by @lpereira)

### DIFF
--- a/common/main.c
+++ b/common/main.c
@@ -95,6 +95,7 @@ void main_gameplay_loop(minefield* mf) {
 	}
 }
 
+#if !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 int main() {
 	platform_init();
 
@@ -118,4 +119,4 @@ int main() {
 	shutdown();
 	return 0;
 }
-
+#endif

--- a/common/main.h
+++ b/common/main.h
@@ -5,3 +5,4 @@ void idle_loop(minefield* mf);
 void draw_minefield(minefield* mf);
 void draw_minefield_contents(minefield* mf);
 void shutdown();
+void main_gameplay_loop(minefield* mf);

--- a/platforms/fuzz/Makefile
+++ b/platforms/fuzz/Makefile
@@ -1,0 +1,11 @@
+CC=clang
+SOURCES=video.c input.c ../../common/main.c  ../../common/minefield.c
+BUILDDIR=build/
+CFLAGS=-g -O1 -fsanitize=address,fuzzer -Wall -pedantic -I../../common -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION=1
+
+all: $(SOURCES)
+	mkdir -p $(BUILDDIR)
+	$(CC) -g -O1 $(SOURCES) $(CFLAGS) -o $(BUILDDIR)mines -fsanitize=address,fuzzer
+
+clean:
+	rm -rf $(BUILDDIR)

--- a/platforms/fuzz/README.md
+++ b/platforms/fuzz/README.md
@@ -1,0 +1,24 @@
+## fuzzer target
+
+This fuzzes the game with libfuzzer/fuzzer sanitizer.
+
+Input contains letters, each one specifying a key that the
+game engine should handle:
+
+* L: move left
+* R: move right
+* U: move up
+* D: move down
+* B: open block
+* F: mark flag
+* Q: quit
+* \n: open
+
+Save a list of commands in a text file and pass it to the built
+executable.  If the environment variable `ASAN_OPTIONS` is set to
+`abort_on_error=1`, you can easily use a debugger like gdb to figure
+out what happened where.
+
+### Build & runtime/debug dependencies
+
+* clang compiler

--- a/platforms/fuzz/input.c
+++ b/platforms/fuzz/input.c
@@ -1,0 +1,70 @@
+#include "main.h"
+#include "common.h"
+#include "minefield.h"
+#include <stdlib.h>
+
+static const uint8_t *fuzz_data, *fuzz_data_end;
+
+uint8_t input_read(uint8_t source)
+{
+	if (fuzz_data < fuzz_data_end) {
+		uint8_t ret = *fuzz_data;
+
+		fuzz_data++;
+
+		switch (ret) {
+		case 'L':
+			return MINE_INPUT_LEFT;
+		case 'R':
+			return MINE_INPUT_RIGHT;
+		case 'U':
+			return MINE_INPUT_UP;
+		case 'D':
+			return MINE_INPUT_DOWN;
+		case '\n':
+			return MINE_INPUT_OPEN;
+		case 'B':
+			return MINE_INPUT_OPEN_BLOCK;
+		case 'F':
+			return MINE_INPUT_FLAG;
+		case 'Q':
+			return MINE_INPUT_QUIT;
+		}
+	}
+
+	return MINE_INPUT_IGNORED;
+}
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	fuzz_data = data;
+	fuzz_data_end = data + size;
+
+	minefield mf;
+
+	setup_minefield(&mf, 10, 10, 5);
+	mf.state = PLAYING_GAME;
+
+	while (mf.state != QUIT)
+		main_gameplay_loop(&mf);
+
+	return 0;
+}
+
+int random_number(int min_num, int max_num)
+{
+	int result = 0, low_num = 0, hi_num = 0;
+
+	if (min_num < max_num)
+	{
+		low_num = min_num;
+		hi_num = max_num + 1; // include max_num in output
+	} else {
+		low_num = max_num + 1; // include max_num in output
+		hi_num = min_num;
+	}
+
+	result = (rand() % (hi_num - low_num)) + low_num;
+	return result;
+}

--- a/platforms/fuzz/video.c
+++ b/platforms/fuzz/video.c
@@ -1,0 +1,14 @@
+#include "minefield.h"
+
+void draw_minefield_contents(minefield* mf)
+{
+}
+
+void draw_minefield(minefield* mf)
+{
+}
+
+void idle_loop()
+{
+}
+


### PR DESCRIPTION
This allows us to test the game engine to find crashes.  Requires the Clang compiler (for the Fuzzer Sanitizer). Instructions in
README.md file.

(contributed by @lpereira)