### PR TITLE
platform_init and platform_shutdown common.h functions

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -20,6 +20,27 @@
 #define JOY_4              4
 
 /**
+ * Platform-specific initialisation code
+ *
+ * Implementation details
+ * ----------------------
+ *
+ * A place to properly initialise graphics mode and sound settings, move tiles and
+ * sprites from ROM to RAM etc.
+ */
+void platform_init();
+
+/**
+ * Platform-specific shutdown code
+ *
+ * Implementation details
+ * ----------------------
+ *
+ * A place to properly change back to text mode, free previous memory allocations etc.
+ */
+void platform_shutdown();
+
+/**
  * Reads input from controller or keyboard, including all the buttons and pad directions
  * and returns immediately. `source` identifies the input source.
  *
@@ -126,7 +147,6 @@ void debug(char* msg, uint8_t value);
  */
 void debug_break();
 
-#ifndef NO_STRINGIFICATION
 /**
  * Breaks execution if not `ok`.
  *
@@ -142,6 +162,7 @@ void debug_break();
  * This macro requires that the platform's C compiler supports stringification of arguments
  * in macros. Otherwise, the `NO_STRINGIFICATION` macro should be defined first.
  */
+#ifndef NO_STRINGIFICATION
 #define assert(ok) \
 	do { if (!(ok)) { debug_msg("Assertion `" #ok "' failed.\nPaused "); debug_break(); } } while(0)
 #else

--- a/common/main.c
+++ b/common/main.c
@@ -35,7 +35,8 @@ void main_gameplay_loop(minefield* mf) {
 	uint8_t has_bomb = (mf->cells[mf->current_cell] & HASBOMB);
 	uint8_t num_bombs_around = (mf->cells[mf->current_cell] & 0x0F);
 	uint8_t num_cells = (mf->width * mf->height);
-	switch(input){
+
+	switch (input) {
 		case MINE_INPUT_LEFT:
 			if (mf->current_cell % mf->width > 0)
 				mf->current_cell--;
@@ -61,7 +62,7 @@ void main_gameplay_loop(minefield* mf) {
 			break;
 
 		case MINE_INPUT_OPEN_BLOCK:
-		    if (!has_bomb && (count_surrounding_flags(mf, x, y) == num_bombs_around)){
+			if (!has_bomb && (count_surrounding_flags(mf, x, y) == num_bombs_around)) {
 				open_cell(mf, x-1, y-1);
 				open_cell(mf, x-1, y);
 				open_cell(mf, x-1, y+1);
@@ -75,11 +76,11 @@ void main_gameplay_loop(minefield* mf) {
 			break;
 
 		case MINE_INPUT_FLAG:
-			if (!(mf->cells[mf->current_cell] & ISOPEN)){
-				if (mf->cells[mf->current_cell] & HASFLAG){
+			if (!(mf->cells[mf->current_cell] & ISOPEN)) {
+				if (mf->cells[mf->current_cell] & HASFLAG) {
 					mf->cells[mf->current_cell] &= ~HASFLAG;
 					mf->cells[mf->current_cell] |= HASQUESTIONMARK;
-				} else if (mf->cells[mf->current_cell] & HASQUESTIONMARK){
+				} else if (mf->cells[mf->current_cell] & HASQUESTIONMARK) {
 					mf->cells[mf->current_cell] &= ~HASQUESTIONMARK;
 				} else {
 					mf->cells[mf->current_cell] |= HASFLAG;
@@ -114,10 +115,13 @@ int main() {
 
 	mf.state = PLAYING_GAME;
 	while (mf.state != QUIT)
+	{
 		main_gameplay_loop(&mf);
+	}
 
-	free(mf.cells);
-	shutdown();
+	free_minefield(&mf);
+	platform_shutdown();
+
 	return 0;
 }
 #endif

--- a/common/main.h
+++ b/common/main.h
@@ -1,8 +1,7 @@
 #include "minefield.h"
 
-void platform_init();
 void idle_loop(minefield* mf);
 void draw_minefield(minefield* mf);
 void draw_minefield_contents(minefield* mf);
-void shutdown();
 void main_gameplay_loop(minefield* mf);
+void free_minefield(minefield* mf);

--- a/common/minefield.c
+++ b/common/minefield.c
@@ -55,6 +55,11 @@ void setup_minefield(minefield* mf, uint8_t width, uint8_t height, uint8_t num_b
 	}
 }
 
+void free_minefield(minefield* mf)
+{
+	free(mf->cells);
+}
+
 void open_cell(minefield* mf, uint8_t x, uint8_t y) {
 	if (CELL(mf, x, y) & (HASQUESTIONMARK | HASFLAG | ISOPEN)){
 		return;

--- a/platforms/gunsmoke/video.c
+++ b/platforms/gunsmoke/video.c
@@ -372,6 +372,6 @@ void draw_minefield(minefield* mf){
 	enable_chars();
 }
 
-void shutdown()
+void platform_shutdown()
 {
 }

--- a/platforms/msx2/video.c
+++ b/platforms/msx2/video.c
@@ -253,7 +253,7 @@ void idle_loop(minefield* mf)
 }
 
 
-void shutdown()
+void platform_shutdown()
 {
     // Cartridge games can't unload.
     __asm__("jp 0");

--- a/platforms/msx2/xorshift.asm
+++ b/platforms/msx2/xorshift.asm
@@ -7,7 +7,7 @@ _set_random_seed::
     ld iy, #_seed
 
     ld a, (hl)
-    or #1
+    or #1               ; guarantees that seed is never zero
     ld 0(iy), a
 
     inc hl
@@ -40,5 +40,5 @@ _xorshift::
 
 .area _DATA
 
-_seed: .dw 1    ; value must not be zero
+_seed: .ds 2
 

--- a/platforms/ncurses/video.c
+++ b/platforms/ncurses/video.c
@@ -119,7 +119,7 @@ void draw_minefield(minefield* mf){
     refresh();
 }
 
-void shutdown()
+void platform_shutdown()
 {
     endwin();
     exit(0);


### PR DESCRIPTION
* Since `minefield->cells` were created in `setup_minefield()`, it makes sense to destroy them in another `*_minefield` function and not in `main()`.
* `platform_init()` has a `platform_shutdown()` for consistency;