### PR TITLE
[msdos] python3 enabled container

### DIFF
--- a/.github/workflows/workflow-build.yaml
+++ b/.github/workflows/workflow-build.yaml
@@ -29,7 +29,7 @@ jobs:
         include:
           - image: docker://pvmm/sdcc:latest
             platform: msx2
-          - image: docker://pvmm/ia16:minimal
+          - image: docker://pvmm/ia16:python3
             platform: msdos
           - image: docker://pvmm/opengl:latest
             platform: opengl


### PR DESCRIPTION
This should enable PR #88 to compile msdos bundle correctly. 