### PR TITLE
[MS-DOS] More size reductions (1136 bytes down)

### DIFF
--- a/platforms/msdos/Makefile
+++ b/platforms/msdos/Makefile
@@ -1,7 +1,7 @@
 CC := ia16-elf-gcc
 SOURCES := video.c input.c ../../common/main.c ../../common/minefield.c ../../common/video-tiles.c
 BUILDDIR := build
-CFLAGS := -mcmodel=small -mregparmcall -Os -flto -Wall -pedantic -I../../common -I. -DNO_UNUSED_MACRO
+CFLAGS := -mcmodel=small -mregparmcall -march=i186 -Os -flto -Wall -pedantic -I../../common -I. -DNO_UNUSED_MACRO
 LDFLAGS := -flto
 SCREEN_RESOLUTION := -DSCREEN_WIDTH=320/8 -DSCREEN_HEIGHT=200/8 -DMINEFIELD_X_OFFSET=10 -DMINEFIELD_Y_OFFSET=2
 

--- a/platforms/msdos/Makefile
+++ b/platforms/msdos/Makefile
@@ -1,7 +1,7 @@
 CC := ia16-elf-gcc
 SOURCES := video.c input.c ../../common/main.c ../../common/minefield.c ../../common/video-tiles.c
 BUILDDIR := build
-CFLAGS := -Os -flto -Wall -pedantic -I../../common -I. -DNO_UNUSED_MACRO
+CFLAGS := -mcmodel=small -mregparmcall -Os -flto -Wall -pedantic -I../../common -I. -DNO_UNUSED_MACRO
 LDFLAGS := -flto
 SCREEN_RESOLUTION := -DSCREEN_WIDTH=320/8 -DSCREEN_HEIGHT=200/8 -DMINEFIELD_X_OFFSET=10 -DMINEFIELD_Y_OFFSET=2
 

--- a/platforms/msdos/Makefile
+++ b/platforms/msdos/Makefile
@@ -2,7 +2,7 @@ CC := ia16-elf-gcc
 SOURCES := video.c input.c ../../common/main.c ../../common/minefield.c ../../common/video-tiles.c
 BUILDDIR := build
 CFLAGS := -Os -flto -Wall -pedantic -I../../common -I. -DNO_UNUSED_MACRO
-LDFLAGS := -li86 -flto
+LDFLAGS := -flto
 SCREEN_RESOLUTION := -DSCREEN_WIDTH=320/8 -DSCREEN_HEIGHT=200/8 -DMINEFIELD_X_OFFSET=10 -DMINEFIELD_Y_OFFSET=2
 
 PYTHON := python3

--- a/platforms/msdos/input.c
+++ b/platforms/msdos/input.c
@@ -1,8 +1,7 @@
 #include "common.h"
 #include "minefield.h"
-#include <stdlib.h>
 #include <stdio.h>
-#include <conio.h>
+#include <stdlib.h>
 
 // Uncomment this to see the keyboard scan code
 // values drawn to screen using game tiles:
@@ -12,50 +11,62 @@
 #include "video-tiles.h"
 #endif
 
+static inline uint8_t getch(void)
+{
+    uint8_t key;
+    asm __volatile("int $0x16" : "=Ral"(key) : "0"((unsigned char)0));
+    return key;
+}
+
 uint8_t input_read(uint8_t source)
 {
-	char c = getch();
+    char c = getch();
+
 #ifdef DEBUGGING
-	set_tile(6,10, ONE_BOMB + c%10 - 1);
-	set_tile(5,10, ONE_BOMB + (c/10)%10 - 1);
-	set_tile(4,10, ONE_BOMB + (c/100)%10 - 1);
+    set_tile(6, 10, ONE_BOMB + c % 10 - 1);
+    set_tile(5, 10, ONE_BOMB + (c / 10) % 10 - 1);
+    set_tile(4, 10, ONE_BOMB + (c / 100) % 10 - 1);
 #endif
 
-	if (c == 0 || c == -32) {
-		c = getch();
-		switch(c) {
-		    case 72: return MINE_INPUT_UP;
-		    case 80: return MINE_INPUT_DOWN;
-		    case 77: return MINE_INPUT_RIGHT;
-		    case 75: return MINE_INPUT_LEFT;
-			default: break;
-		}
-	} else if (c == (int)'\n' || c == (int)' ') {
-		return MINE_INPUT_OPEN;
-	} else if (c == (int)'b' || c == (int)'B') {
-		return MINE_INPUT_OPEN_BLOCK;
-	} else if (c == (int)'f' || c == (int)'F') {
-		return MINE_INPUT_FLAG;
-	} else if (c == (int)'q' || c == (int)'Q' || c == 27) {
-		return MINE_INPUT_QUIT;
-	}
-		
-	return MINE_INPUT_IGNORED;
+    if (c == 0 || c == -32) {
+        c = getch();
+        switch (c) {
+        case 72:
+            return MINE_INPUT_UP;
+        case 80:
+            return MINE_INPUT_DOWN;
+        case 77:
+            return MINE_INPUT_RIGHT;
+        case 75:
+            return MINE_INPUT_LEFT;
+        default:
+            break;
+        }
+    } else if (c == (int)'\n' || c == (int)' ') {
+        return MINE_INPUT_OPEN;
+    } else if (c == (int)'b' || c == (int)'B') {
+        return MINE_INPUT_OPEN_BLOCK;
+    } else if (c == (int)'f' || c == (int)'F') {
+        return MINE_INPUT_FLAG;
+    } else if (c == (int)'q' || c == (int)'Q' || c == 27) {
+        return MINE_INPUT_QUIT;
+    }
+
+    return MINE_INPUT_IGNORED;
 }
 
 int random_number(int min_num, int max_num)
 {
-	int result = 0, low_num = 0, hi_num = 0;
+    int result = 0, low_num = 0, hi_num = 0;
 
-	if (min_num < max_num)
-	{
-		low_num = min_num;
-		hi_num = max_num + 1; // include max_num in output
-	} else {
-		low_num = max_num + 1; // include max_num in output
-		hi_num = min_num;
-	}
+    if (min_num < max_num) {
+        low_num = min_num;
+        hi_num = max_num + 1; // include max_num in output
+    } else {
+        low_num = max_num + 1; // include max_num in output
+        hi_num = min_num;
+    }
 
-	result = (rand() % (hi_num - low_num)) + low_num;
-	return result;
+    result = (rand() % (hi_num - low_num)) + low_num;
+    return result;
 }


### PR DESCRIPTION
Three patches, each making a change:

- Remove dependency on libi86. Reduces code size and makes the game depend only on BIOS calls. (Makes it easier to do a boot-to-game thing). Saves over 420 bytes
- Pass parameters by registers and use `small` memory model. Saves over 520 bytes
- Builds with -march=i186. Saves 192 bytes
