### PR TITLE
[common] Reduce one multiplication per initialization

### DIFF
--- a/common/minefield.c
+++ b/common/minefield.c
@@ -30,8 +30,13 @@ void fill_minefield(minefield* mf, uint8_t num_bombs)
 
 	// Place bombs:
 	while (num_bombs--) {
-		uint8_t x = random_number(0, mf->width - 1);
-		uint8_t y = random_number(0, mf->height - 1);
+		uint8_t x, y;
+
+		do {
+			x = random_number(0, mf->width - 1);
+			y = random_number(0, mf->height - 1);
+		} while (CELL(mf, x, y) & HASBOMB);
+
 		CELL(mf, x, y) |= HASBOMB;
 	}
 

--- a/common/minefield.c
+++ b/common/minefield.c
@@ -72,7 +72,7 @@ minefield* init_minefield()
 	minefield* mf = calloc(1, sizeof(minefield));
 	mf->width = 10;
 	mf->height = 10;
-	mf->cells = calloc(mf->width * mf->height, sizeof(uint8_t));
+	mf->cells = calloc(mf->width, mf->height);
 
 	return mf;
 }


### PR DESCRIPTION
Two misc fixes:

- Remove one multiplication from a calloc call
- Try placing a bomb somewhere else if there was a bomb there already
