### PR TITLE
[psx] changed screen width to video.c to not draw scenario

### DIFF
--- a/platforms/psx/CMakeLists.txt
+++ b/platforms/psx/CMakeLists.txt
@@ -9,8 +9,6 @@ project(
 )
 
 # Screen resolution macros
-add_compile_definitions(SCREEN_WIDTH=320)
-add_compile_definitions(SCREEN_HEIGHT=240)
 add_compile_definitions(MINEFIELD_X_OFFSET=6)
 add_compile_definitions(MINEFIELD_Y_OFFSET=5)
 # Other macros

--- a/platforms/psx/video.c
+++ b/platforms/psx/video.c
@@ -9,6 +9,8 @@
 #define OTLEN 8
 #define TILESIZE 10
 #define TILESKIP 9
+#define SCREEN_WIDTH 320
+#define SCREEN_HEIGHT 240
 
 DISPENV disp[2];
 DRAWENV draw[2];


### PR DESCRIPTION
draw_scenario only draws when SCREEN_WIDTH is provided, so I defined it on video.c and removed from CMakeLists. It was yielding a strange behavior on PSX.