### PR TITLE
[msx2] clean up mouse code

### DIFF
--- a/platforms/msx2/Makefile
+++ b/platforms/msx2/Makefile
@@ -51,7 +51,7 @@ $(BUILDDIR)/%.rel: ../../common/%.c $(BUILDDIR) ../../common/common.h
 	$(Z80_CC) $(Z80_CFLAGS) $(SCREEN_RESOLUTION) -c $< -o $@
 
 $(BUILDDIR)/%.rel: %.c $(HEADERS) $(BUILDDIR)
-	$(Z80_CC) $(Z80_CFLAGS) -c $< -o $@
+	$(Z80_CC) $(Z80_CFLAGS) $(SCREEN_RESOLUTION) -c $< -o $@
 
 $(BUILDDIR)/%.rel: %.asm $(HEADERS) $(BUILDDIR)
 	$(Z80_AS) -g -o $@ $<

--- a/platforms/msx2/mouse.c
+++ b/platforms/msx2/mouse.c
@@ -1,0 +1,87 @@
+#include <string.h>
+#include <stdbool.h>
+#include "msx2.h"
+#include "common.h"
+#include "video-tiles.h"
+#include "game.h"
+#include "minefield.h"
+
+
+/* mouse data */
+static struct mouse mouse;
+static int x = 255;
+static int y = 212;
+static bool l_pressed = false;
+static bool r_pressed = false;
+static bool ignored = false;
+
+
+void update_mouse(minefield* mf)
+{
+    read_mouse(&mouse, 1);
+
+    x -= mouse.dx;
+    if (x > 255) x = 255;
+    else if (x < 0) x = 0;
+
+    y -= mouse.dy;
+    if (y > 212) y = 212;
+    else if (y < 0) y = 0;
+
+    put_mouse(x, y);
+
+    if (mf->state == PLAYING_GAME) {
+        uint8_t cell_x = x / 8 - MINEFIELD_X_OFFSET;
+        uint8_t cell_y = y / 8 - MINEFIELD_Y_OFFSET;
+        if (cell_x & 1 || cell_y & 1) return;
+        cell_x /= 2;
+        cell_y /= 2;
+        if (cell_x >= mf->width || cell_y >= mf->height) return;
+
+        /* ignore presses again until both button1 and button2 are released */
+        if (mouse.l_button + mouse.r_button == 5 && ignored) {
+            ignored = false;
+        }
+
+        if (ignored) {
+            return;
+        }
+
+        /* was left button released? */
+        if (mouse.l_button && l_pressed) {
+            l_pressed = false;
+
+            /* left button alone? */
+            if (!r_pressed) {
+                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_OPEN);
+            } else {
+                /* or simultaneous clicks? */
+                r_pressed = false;
+                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_OPEN_BLOCK);
+                ignored = true;
+            }
+            return;
+        } else if (!mouse.l_button) {
+            /* remembers if left button was pressed */
+            l_pressed = true;
+        }
+    
+        /* was right button released? */
+        if (mouse.r_button && r_pressed) {
+            r_pressed = false;
+
+            /* right button alone? */
+            if (!l_pressed) {
+                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_FLAG);
+            } else {
+                /* or simultaneous clicks? */
+                l_pressed = false;
+                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_OPEN_BLOCK);
+                ignored = true;
+            }
+        } else if (!mouse.r_button) {
+            /* remembers if right button was pressed */
+            r_pressed = true;
+        }
+    }
+}

--- a/platforms/msx2/msx2.h
+++ b/platforms/msx2/msx2.h
@@ -89,7 +89,7 @@ struct mouse {
     uint8_t r_button; /* 1 = OFF, 2 = ON */
 };
 
-void read_mouse(struct mouse* mouse, uint8_t source);
+void read_mouse(struct mouse* mouse, uint8_t source) SDCCCALL0;
 
 void put_mouse(uint8_t x, uint8_t y);
 

--- a/platforms/msx2/read_mouse.asm
+++ b/platforms/msx2/read_mouse.asm
@@ -1,3 +1,5 @@
+; void read_mouse(struct mouse* mouse, uint8_t source) __sdcccall(0)
+
 .globl read_mouse
 
 REGWTP = 0xA0           ; register write port

--- a/platforms/msx2/video.c
+++ b/platforms/msx2/video.c
@@ -205,76 +205,16 @@ void update_counter(minefield* mf)
 }
 
 
-static struct mouse mouse;
-static int x = 255;
-static int y = 212;
-static bool l_pressed = false;
-static bool r_pressed = false;
-static bool ignored = false;
+extern inline void update_mouse(minefield* mf);
+
 
 void idle_update(minefield* mf)
 {
-    read_mouse(&mouse, 1);
+    static uint8_t fifth = 0;
 
-    x -= mouse.dx;
-    if (x > 255) x = 255;
-    else if (x < 0) x = 0;
-
-    y -= mouse.dy;
-    if (y > 212) y = 212;
-    else if (y < 0) y = 0;
-
-    put_mouse(x, y);
-
-    if (mf->state == PLAYING_GAME) {
-        uint8_t cell_x = x / 8 - MINEFIELD_X_OFFSET;
-        uint8_t cell_y = y / 8 - MINEFIELD_Y_OFFSET;
-        if (cell_x & 1 || cell_y & 1) return;
-        cell_x /= 2;
-        cell_y /= 2;
-        if (cell_x >= mf->width || cell_y >= mf->height) return;
-
-        /* ignore presses again after both button1 and button2 are released */
-        if (mouse.l_button + mouse.r_button == 5 && ignored) {
-            ignored = false;
-        }
-
-        if (ignored) {
-            return;
-        }
-
-        /* is left button released? */
-        if (mouse.l_button) {
-            /* was it pressed before? */
-            if (l_pressed && !r_pressed) {
-                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_OPEN);
-                l_pressed = false;
-                return;
-            } else if (l_pressed) {
-                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_OPEN_BLOCK);
-                l_pressed = false;
-                r_pressed = false;
-                ignored = true;
-                return;
-            }
-        } else {
-            l_pressed = true;
-        }
-    
-        /* is right button released? */
-        if (mouse.r_button) {
-            /* was it pressed before? */
-            if (r_pressed && !l_pressed) {
-                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_FLAG);
-            } else if (r_pressed) {
-                set_minefield_cell(mf, cell_x, cell_y, MINE_INPUT_OPEN_BLOCK);
-                l_pressed = false;
-                ignored = true;
-            }
-            r_pressed = false;
-        } else {
-            r_pressed = true;
-        }
+    if (++fifth == 5) {
+        fifth = 0;
+        update_mouse(mf);
     }
 }
 


### PR DESCRIPTION
* new `update_mouse` function separated from `idle_update`.
* it's not necessary to update mouse position at every frame. Once every fifth frame is good enough.
* Moving mouse code to a different file for compartmentalisation is a good idea too.
* read_mouse function missing `__sdcccall(0)` directive (SDCC 4.2.0 fix).