### PR TITLE
[msx2] using HMMM's slightly faster blitter

### DIFF
--- a/platforms/msx2/msx2.h
+++ b/platforms/msx2/msx2.h
@@ -32,6 +32,7 @@
 
 /* VDP operation (combine it with pixel operation above) */
 #define VDP_LMMM            0b10010000
+#define VDP_HMMM            0b11010000
 
 /* vblank hook, 60 times per second */
 #define HTIMI               0xfd9f

--- a/platforms/msx2/video.c
+++ b/platforms/msx2/video.c
@@ -110,7 +110,7 @@ void video_init()
 void set_tile(uint8_t dst_x, uint8_t dst_y, uint8_t tile)
 {
     /* copy 8x8 block from page 1 (hidden page) to page 0 (visible page) */
-    vdp(TILE_X[tile], TILE_Y[tile], dst_x * 8, dst_y * 8, 8, 8, DIR_DEFAULT, VDP_LMMM | PO_IMP);
+    vdp(TILE_X[tile], TILE_Y[tile], dst_x * 8, dst_y * 8, 8, 8, DIR_DEFAULT, VDP_HMMM);
 }
 
 


### PR DESCRIPTION
Replacing slower Logical Move VRAM to VRAM (LMMM) by High Speed Move VRAM to VRAM (HMMM) since logic operators are not necessary for regular block copying. 